### PR TITLE
Fix for installing Magento with this module already included in Composer

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -29,6 +29,22 @@
     <preference for="Divante\PimcoreIntegration\Http\Response\Transformator\Data\PropertyResolverInterface" type="Divante\PimcoreIntegration\Http\Response\Transformator\Data\PropertyResolver"/>
     <preference for="Divante\PimcoreIntegration\Queue\Action\Product\GalleryImagesUpdaterInterface" type="Divante\PimcoreIntegration\Queue\Action\Product\GalleryImagesUpdater"/>
     <preference for="Magento\ConfigurableProduct\Plugin\Model\ResourceModel\Attribute\InStockOptionSelectBuilder" type="Divante\PimcoreIntegration\Plugin\Model\ResourceModel\Attribute\InStockOptionSelectBuilder" />
+    
+    <type name="Divante\PimcoreIntegration\Console\Command\AssetsImportCommand">
+        <arguments>
+            <argument name="queueProcessor" xsi:type="object">Divante\PimcoreIntegration\Queue\Processor\AssetQueueProcessor\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Divante\PimcoreIntegration\Console\Command\ProductImportCommand">
+        <arguments>
+            <argument name="productQueueProcessor" xsi:type="object">Divante\PimcoreIntegration\Queue\Processor\ProductQueueProcessor\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Divante\PimcoreIntegration\Console\Command\CategoryImportCommand">
+        <arguments>
+            <argument name="categoryQueueProcessor" xsi:type="object">Divante\PimcoreIntegration\Queue\Processor\CategoryQueueProcessor\Proxy</argument>
+        </arguments>
+    </type>
     <type name="Divante\PimcoreIntegration\System\Config">
         <arguments>
             <argument name="scope" xsi:type="string">store</argument>


### PR DESCRIPTION
If a `composer.json` file is already present (with this module included) and you run `bin/magento setup:install`, you will get this error:
```
 [Progress: 4 / 953]
 Installing database schema:
 In Mysql.php line 110:
                                                                                
   SQLSTATE[42S02]: Base table or view not found: 1146 Table 'build_db.store_w  
   ebsite' doesn't exist, query was: SELECT `store_website`.* FROM `store_webs  
   ite`                                                                         
                                                                                
 In Mysql.php line 91:
                                                                                
   SQLSTATE[42S02]: Base table or view not found: 1146 Table 'build_db.store_w  
   ebsite' doesn't exist     
```

The problem is that somewhere in the dependency chain, a constructor makes a database call.

By utilizing proxies, we are able to easily resolve the problem.