### PR TITLE
Also consider database schema when retrieving AUTO_INCREMENT value

### DIFF
--- a/Listeners/AttributeSet/NameResolver.php
+++ b/Listeners/AttributeSet/NameResolver.php
@@ -42,7 +42,8 @@ class NameResolver implements NameResolverInterface
             ->from(
                 'information_schema.TABLES',
                 'AUTO_INCREMENT'
-            )->where('TABLE_NAME = ?', $connection->getTableName('eav_attribute_set'));
+            )->where('TABLE_NAME = ?', $connection->getTableName('eav_attribute_set')
+            )->where('TABLE_SCHEMA = ?', $this->resource->getSchemaName(ResourceConnection::DEFAULT_CONNECTION));
 
         return sprintf('pimcore-set-%s', (int)$connection->fetchOne($query));
     }


### PR DESCRIPTION
We got the following exception when importing products: "A "pimcore-set-16" attribute set name already exists. Create a new name and try again."
This is caused by the way the next auto increment is determined for the the name of the pimcore-set.
The information schema is server wide, so this causes issues when you have multiple Magento 2 instances in the same MySQL server. It will return the auto increment value for the wrong database. This PR fixes the issue by also considering the schema (db name).