### PR TITLE
Commands dependencies changes to factories

### DIFF
--- a/Console/Command/AssetsImportCommand.php
+++ b/Console/Command/AssetsImportCommand.php
@@ -8,7 +8,7 @@
 
 namespace Divante\PimcoreIntegration\Console\Command;
 
-use Divante\PimcoreIntegration\Queue\Processor\AssetQueueProcessor;
+use Divante\PimcoreIntegration\Queue\Processor\AssetQueueProcessorFactory;
 use Magento\Framework\App\State;
 use Magento\Framework\Registry;
 use Symfony\Component\Console\Command\Command;
@@ -21,9 +21,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 class AssetsImportCommand extends Command
 {
     /**
-     * @var AssetQueueProcessor
+     * @var AssetQueueProcessorFactory
      */
-    private $queueProcessor;
+    private $queueProcessorFactory;
 
     /**
      * @var State
@@ -38,14 +38,14 @@ class AssetsImportCommand extends Command
     /**
      * AssetsImportCommand constructor.
      *
-     * @param AssetQueueProcessor $queueProcessor
+     * @param AssetQueueProcessorFactory $queueProcessorFactory
      * @param State $state
      * @param Registry $registry
      * @param null $name
      */
-    public function __construct(AssetQueueProcessor $queueProcessor, State $state, Registry $registry, $name = null)
+    public function __construct(AssetQueueProcessorFactory $queueProcessorFactory, State $state, Registry $registry, $name = null)
     {
-        $this->queueProcessor = $queueProcessor;
+        $this->queueProcessorFactory = $queueProcessorFactory;
         $this->state = $state;
         $this->registry = $registry;
 
@@ -84,7 +84,9 @@ class AssetsImportCommand extends Command
         $output->writeln(sprintf('<info>Started at %s</info>', (new \DateTime())->format('Y-m-d H:i:s')));
         $output->writeln('Processing...');
 
-        $this->queueProcessor->process();
+        $queueProcessor = $this->queueProcessorFactory->create();
+
+        $queueProcessor->process();
 
         $end = $this->getCurrentMs();
 

--- a/Console/Command/CategoryImportCommand.php
+++ b/Console/Command/CategoryImportCommand.php
@@ -8,7 +8,7 @@
 
 namespace Divante\PimcoreIntegration\Console\Command;
 
-use Divante\PimcoreIntegration\Queue\Processor\CategoryQueueProcessor;
+use Divante\PimcoreIntegration\Queue\Processor\CategoryQueueProcessorFactory;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\State;
 use Magento\Framework\Registry;
@@ -22,9 +22,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CategoryImportCommand extends Command
 {
     /**
-     * @var CategoryQueueProcessor
+     * @var CategoryQueueProcessorFactory
      */
-    private $categoryQueueProcessor;
+    private $categoryQueueProcessorFactory;
 
     /**
      * @var State
@@ -39,20 +39,20 @@ class CategoryImportCommand extends Command
     /**
      * CategoryImport constructor.
      *
-     * @param CategoryQueueProcessor $categoryQueueProcessor
+     * @param CategoryQueueProcessorFactory $categoryQueueProcessorFactory
      * @param State $state
      * @param Registry $registry
      * @param null $name
      */
     public function __construct(
-        CategoryQueueProcessor $categoryQueueProcessor,
+        CategoryQueueProcessorFactory $categoryQueueProcessorFactory,
         State $state,
         Registry $registry,
         $name = null
     ) {
         parent::__construct($name);
 
-        $this->categoryQueueProcessor = $categoryQueueProcessor;
+        $this->categoryQueueProcessorFactory = $categoryQueueProcessorFactory;
         $this->state = $state;
         $this->registry = $registry;
     }
@@ -91,7 +91,9 @@ class CategoryImportCommand extends Command
         $output->writeln(sprintf('<info>Started at %s</info>', (new \DateTime())->format('Y-m-d H:i:s')));
         $output->writeln('Processing...');
 
-        $this->categoryQueueProcessor->process();
+        $categoryQueueProcessor = $this->categoryQueueProcessorFactory->create();
+
+        $categoryQueueProcessor->process();
 
         $end = $this->getCurrentMs();
 

--- a/Console/Command/ProductImportCommand.php
+++ b/Console/Command/ProductImportCommand.php
@@ -8,7 +8,7 @@
 
 namespace Divante\PimcoreIntegration\Console\Command;
 
-use Divante\PimcoreIntegration\Queue\Processor\ProductQueueProcessor;
+use Divante\PimcoreIntegration\Queue\Processor\ProductQueueProcessorFactory;
 use Magento\Framework\App\State;
 use Magento\Framework\Registry;
 use Symfony\Component\Console\Command\Command;
@@ -21,9 +21,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ProductImportCommand extends Command
 {
     /**
-     * @var ProductQueueProcessor
+     * @var ProductQueueProcessorFactory
      */
-    private $productQueueProcessor;
+    private $productQueueProcessorFactory;
 
     /**
      * @var State
@@ -38,20 +38,20 @@ class ProductImportCommand extends Command
     /**
      * ProductImport constructor.
      *
-     * @param ProductQueueProcessor $productQueueProcessor
+     * @param ProductQueueProcessorFactory $productQueueProcessorFactory
      * @param State $state
      * @param Registry $registry
      * @param null $name
      */
     public function __construct(
-        ProductQueueProcessor $productQueueProcessor,
+        ProductQueueProcessorFactory $productQueueProcessorFactory,
         State $state,
         Registry $registry,
         $name = null
     ) {
         parent::__construct($name);
 
-        $this->productQueueProcessor = $productQueueProcessor;
+        $this->productQueueProcessorFactory = $productQueueProcessorFactory;
         $this->state = $state;
         $this->registry = $registry;
     }
@@ -90,7 +90,9 @@ class ProductImportCommand extends Command
         $output->writeln(sprintf('<info>Started at %s</info>', (new \DateTime())->format('Y-m-d H:i:s')));
         $output->writeln('Processing...');
 
-        $this->productQueueProcessor->process();
+        $productQueueProcessor = $this->productQueueProcessorFactory->create();
+
+        $productQueueProcessor->process();
 
         $end = $this->getCurrentMs();
 


### PR DESCRIPTION
In command classes, factories should be injected as dependencies to avoid instantiating those classes f.eg. during clean magento installation.

For now, installation attempt returns an error:

![connector-installation-error](https://user-images.githubusercontent.com/10661401/78018142-a4a25700-734d-11ea-9a07-cae1c8ca58a1.png)

This is because injected classes in commands depend on LoggerFactory class which instantiate in constructor preferred logger class based on magento App\Config stores, which at the time of installation doesn't exist.