### PR TITLE
Mark method beforeReturn in ProductTypeResolver as public so it can be the target of a plugin

### DIFF
--- a/Http/Response/Transformator/ProductTypeResolver.php
+++ b/Http/Response/Transformator/ProductTypeResolver.php
@@ -55,7 +55,7 @@ class ProductTypeResolver
      *
      * @return array
      */
-    protected function beforeReturn(array $data, string $type): array
+    public function beforeReturn(array $data, string $type): array
     {
         return [$data, $type];
     }


### PR DESCRIPTION
Currently method: Divante\PimcoreIntegration\Http\Response\Transformator\ProductTypeResolver::beforeReturn has protected visibility which means that it cannot be targetted as a plugin. The method description explicitly states that this method should be used in a plugin to override any default behaviour but this is impossible since it has protected visibility. 