### PR TITLE
Related products linking bug fix

### DIFF
--- a/Listeners/RelatedProductsLinkerListener.php
+++ b/Listeners/RelatedProductsLinkerListener.php
@@ -76,12 +76,12 @@ class RelatedProductsLinkerListener implements ObserverInterface
             return;
         }
 
-        $productLinks = $this->linkInterfaceFactory->create();
-
         $links = [];
 
         foreach ($collection->getItems() as $item) {
-            $links[] = $productLinks
+            $productLink = $this->linkInterfaceFactory->create();
+            
+            $links[] = $productLink
                 ->setSku($pimcoreProduct->getData('sku'))
                 ->setLinkedProductSku($item->getData('sku'))
                 ->setLinkType("related");


### PR DESCRIPTION
Object reference. Links array is filled with the same object. when having multiple related products you only get the last product.